### PR TITLE
refactor: use fake timers with dataviz spec

### DIFF
--- a/tests/unit/datavisualisations/StackedBarChart.spec.js
+++ b/tests/unit/datavisualisations/StackedBarChart.spec.js
@@ -33,7 +33,8 @@ describe('StackedBarChart.vue', () => {
       wrapper = mount(StackedBarChart, { propsData })
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+      await vi.runAllTimersAsync()
       vi.useRealTimers()
     })
 

--- a/tests/unit/datavisualisations/StackedBarChart.spec.js
+++ b/tests/unit/datavisualisations/StackedBarChart.spec.js
@@ -19,6 +19,7 @@ describe('StackedBarChart.vue', () => {
     let wrapper
 
     beforeEach(async () => {
+      vi.useFakeTimers()
 
       const propsData = {
         data: [
@@ -30,6 +31,10 @@ describe('StackedBarChart.vue', () => {
       }
 
       wrapper = mount(StackedBarChart, { propsData })
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
     })
 
     it('is a Vue instance', () => {
@@ -109,14 +114,14 @@ describe('StackedBarChart.vue', () => {
       const budgetLegend = wrapper.findAll('.stacked-bar-chart__legend__item').at(0)
       expect(budgetLegend.classes('stacked-bar-chart__legend__item--highlighted')).toBeFalsy()
       budgetLegend.trigger('mouseover')
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay)
       expect(budgetLegend.classes('stacked-bar-chart__legend__item--highlighted')).toBeTruthy()
     })
 
     it('hightlight the bars for "budget"', async () => {
       const budgetLegend = wrapper.findAll('.stacked-bar-chart__legend__item').at(0)
       budgetLegend.trigger('mouseover')
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay)
       const budgetBars = wrapper.findAll('.stacked-bar-chart__groups__item__bars__item--budget')
       expect(budgetBars.at(0).classes('stacked-bar-chart__groups__item__bars__item--highlighted')).toBeTruthy()
       expect(budgetBars.at(1).classes('stacked-bar-chart__groups__item__bars__item--highlighted')).toBeTruthy()
@@ -127,7 +132,7 @@ describe('StackedBarChart.vue', () => {
     it('hightlight the bars for "box_office"', async () => {
       const boxOfficeLegend = wrapper.findAll('.stacked-bar-chart__legend__item').at(1)
       boxOfficeLegend.trigger('mouseover')
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay)
       const budgetBars = wrapper.findAll('.stacked-bar-chart__groups__item__bars__item--box-office')
       expect(budgetBars.at(0).classes('stacked-bar-chart__groups__item__bars__item--highlighted')).toBeTruthy()
       expect(budgetBars.at(1).classes('stacked-bar-chart__groups__item__bars__item--highlighted')).toBeTruthy()
@@ -143,7 +148,7 @@ describe('StackedBarChart.vue', () => {
       expect(budgetLegend.classes('stacked-bar-chart__legend__item--highlighted')).toBeFalsy()
       expect(boxOfficeLegend.classes('stacked-bar-chart__legend__item--highlighted')).toBeTruthy()
       budgetLegend.trigger('mouseover')
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay)
       expect(budgetLegend.classes('stacked-bar-chart__legend__item--highlighted')).toBeTruthy()
       expect(boxOfficeLegend.classes('stacked-bar-chart__legend__item--highlighted')).toBeFalsy()
     })
@@ -152,9 +157,9 @@ describe('StackedBarChart.vue', () => {
       const boxOfficeLegend = wrapper.findAll('.stacked-bar-chart__legend__item').at(1)
       boxOfficeLegend.trigger('mouseover')
       expect(boxOfficeLegend.classes('stacked-bar-chart__legend__item--highlighted')).toBeFalsy()
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay / 2))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay / 2)
       expect(boxOfficeLegend.classes('stacked-bar-chart__legend__item--highlighted')).toBeFalsy()
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay / 2))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay * 2)
       expect(boxOfficeLegend.classes('stacked-bar-chart__legend__item--highlighted')).toBeTruthy()
     })
 

--- a/tests/unit/datavisualisations/StackedColumnChart.spec.js
+++ b/tests/unit/datavisualisations/StackedColumnChart.spec.js
@@ -25,6 +25,8 @@ describe('StackedColumnChart.vue', () => {
     let wrapper
 
     beforeEach(async () => {
+      vi.useFakeTimers()
+
       const propsData = {
         highlightDelay: 2,
         data: [
@@ -36,6 +38,10 @@ describe('StackedColumnChart.vue', () => {
       }
 
       wrapper = mount(StackedColumnChart, { propsData, attachTo: createContainer() })
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
     })
 
     it('is a Vue instance', () => {
@@ -115,14 +121,14 @@ describe('StackedColumnChart.vue', () => {
       const fooLegend = wrapper.findAll('.stacked-column-chart__legend__item').at(0)
       expect(fooLegend.classes('stacked-column-chart__legend__item--highlighted')).toBeFalsy()
       fooLegend.trigger('mouseover')
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay + 10)
       expect(fooLegend.classes('stacked-column-chart__legend__item--highlighted')).toBeTruthy()
     })
 
     it('hightlight the columns for "foo"', async () => {
       const fooLegend = wrapper.findAll('.stacked-column-chart__legend__item').at(0)
       fooLegend.trigger('mouseover')
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay)
       const fooColumns = wrapper.findAll('.stacked-column-chart__groups__item__bars__item--foo')
       expect(fooColumns.at(0).classes('stacked-column-chart__groups__item__bars__item--highlighted')).toBeTruthy()
       expect(fooColumns.at(1).classes('stacked-column-chart__groups__item__bars__item--highlighted')).toBeTruthy()
@@ -133,7 +139,7 @@ describe('StackedColumnChart.vue', () => {
     it('hightlight the columns for "bar"', async () => {
       const barLegend = wrapper.findAll('.stacked-column-chart__legend__item').at(1)
       barLegend.trigger('mouseover')
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay)
       const budgetBars = wrapper.findAll('.stacked-column-chart__groups__item__bars__item--bar')
       expect(budgetBars.at(0).classes('stacked-column-chart__groups__item__bars__item--highlighted')).toBeTruthy()
       expect(budgetBars.at(1).classes('stacked-column-chart__groups__item__bars__item--highlighted')).toBeTruthy()
@@ -149,7 +155,7 @@ describe('StackedColumnChart.vue', () => {
       expect(fooLegend.classes('stacked-column-chart__legend__item--highlighted')).toBeFalsy()
       expect(barLegend.classes('stacked-column-chart__legend__item--highlighted')).toBeTruthy()
       fooLegend.trigger('mouseover')
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay)
       expect(fooLegend.classes('stacked-column-chart__legend__item--highlighted')).toBeTruthy()
       expect(barLegend.classes('stacked-column-chart__legend__item--highlighted')).toBeFalsy()
     })
@@ -159,9 +165,9 @@ describe('StackedColumnChart.vue', () => {
       wrapper.setProps({ highlightDelay: 150 })
       barLegend.trigger('mouseover')
       expect(barLegend.classes('stacked-column-chart__legend__item--highlighted')).toBeFalsy()
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay / 2))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay / 2)
       expect(barLegend.classes('stacked-column-chart__legend__item--highlighted')).toBeFalsy()
-      await new Promise(r => setTimeout(r, wrapper.vm.highlightDelay / 2))
+      await vi.advanceTimersByTimeAsync(wrapper.vm.highlightDelay * 2)
       expect(barLegend.classes('stacked-column-chart__legend__item--highlighted')).toBeTruthy()
     })
 

--- a/tests/unit/datavisualisations/StackedColumnChart.spec.js
+++ b/tests/unit/datavisualisations/StackedColumnChart.spec.js
@@ -40,10 +40,11 @@ describe('StackedColumnChart.vue', () => {
       wrapper = mount(StackedColumnChart, { propsData, attachTo: createContainer() })
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+      await vi.runAllTimersAsync()
       vi.useRealTimers()
     })
-
+    
     it('is a Vue instance', () => {
       expect(wrapper.vm).toBeTruthy()
     })


### PR DESCRIPTION
Both `StackedBarChart` and `StackedColumnChart` use a delay before showing the highlight on mouseover. This "highlight delay" used to be tested using setTimeout in the spec. This method has two major flaws:

* behavior is erratic, sometime the test is failing
* testing time is longer because the test runner actually has to wait for the timeout

To solve this, this PR uses fake timers: https://vitest.dev/guide/mocking.html#timers