### PR TITLE
Feat: add optional "about us" section in Generic Footer

### DIFF
--- a/lib/components/GenericFooter.vue
+++ b/lib/components/GenericFooter.vue
@@ -43,7 +43,7 @@
               <ul class="list-unstyled">
                 <li class="list-unstyled-item">
                   <a
-                    href="https://www.icij.org/investigations/uber-files/"
+                    href="https://www.icij.org/about/our-team/"
                     target="_blank"
                   >
                     Our team
@@ -51,7 +51,7 @@
                 </li>
                 <li class="list-unstyled-item">
                   <a
-                    href="https://www.icij.org/investigations/uber-files/"
+                    href="https://www.icij.org/about/our-supporters/"
                     target="_blank"
                   >
                     Our supporters
@@ -59,7 +59,7 @@
                 </li>
                 <li class="list-unstyled-item">
                   <a
-                    href="https://www.icij.org/investigations/uber-files/"
+                    href="https://www.icij.org/about/awards/"
                     target="_blank"
                   >
                     ICIJ's Awards
@@ -67,7 +67,7 @@
                 </li>
                 <li class="list-unstyled-item">
                   <a
-                    href="https://www.icij.org/investigations/uber-files/"
+                    href="https://www.icij.org/about/corporate/"
                     target="_blank"
                   >
                     Corportate
@@ -75,7 +75,7 @@
                 </li>
                 <li class="list-unstyled-item">
                   <a
-                    href="https://www.icij.org/investigations/uber-files/"
+                    href="https://www.icij.org/about/work-with-us/"
                     target="_blank"
                   >
                     Work with us
@@ -83,7 +83,7 @@
                 </li>
                 <li class="list-unstyled-item">
                   <a
-                    href="https://www.icij.org/investigations/uber-files/"
+                    href="https://www.icij.org/journalists/"
                     target="_blank"
                   >
                     Journalists

--- a/lib/components/GenericFooter.vue
+++ b/lib/components/GenericFooter.vue
@@ -36,7 +36,7 @@
         </div>
         <div class="col-12 col-lg-7">
           <div class="row justify-content-end">
-            <div v-if="includeAboutUs" class="col-6 col-lg-4">
+            <div v-if="showAboutUs" class="col-6 col-lg-4">
               <h5 class="text-uppercase mb-3">
                 About Us
               </h5>
@@ -239,9 +239,9 @@ export default {
       default: null
     },
     /**
-     * Whether to include the About Us column or not
+     * Whether to show the About Us column or not
      */
-    includeAboutUs: {
+    showAboutUs: {
       type: Boolean,
       default: false
     }

--- a/lib/components/GenericFooter.vue
+++ b/lib/components/GenericFooter.vue
@@ -2,7 +2,7 @@
   <footer class="generic-footer">
     <div class="container">
       <div class="row">
-        <div class="col-md-5">
+        <div class="col-12 col-lg-5">
           <h5 class="text-uppercase text-white clearfix generic-footer__icij mb-3">
             <a
               href="https://icij.org"
@@ -34,12 +34,69 @@
           <!-- @slot Additional content on the left side of the footer -->
           <slot name="left" />
         </div>
-        <div class="col-md-7">
+        <div class="col-12 col-lg-7">
           <div class="row justify-content-end">
-            <div class="col-md-5">
+            <div v-if="includeAboutUs" class="col-6 col-lg-4">
+              <h5 class="text-uppercase mb-3">
+                About Us
+              </h5>
+              <ul class="list-unstyled">
+                <li class="list-unstyled-item">
+                  <a
+                    href="https://www.icij.org/investigations/uber-files/"
+                    target="_blank"
+                  >
+                    Our team
+                  </a>
+                </li>
+                <li class="list-unstyled-item">
+                  <a
+                    href="https://www.icij.org/investigations/uber-files/"
+                    target="_blank"
+                  >
+                    Our supporters
+                  </a>
+                </li>
+                <li class="list-unstyled-item">
+                  <a
+                    href="https://www.icij.org/investigations/uber-files/"
+                    target="_blank"
+                  >
+                    ICIJ's Awards
+                  </a>
+                </li>
+                <li class="list-unstyled-item">
+                  <a
+                    href="https://www.icij.org/investigations/uber-files/"
+                    target="_blank"
+                  >
+                    Corportate
+                  </a>
+                </li>
+                <li class="list-unstyled-item">
+                  <a
+                    href="https://www.icij.org/investigations/uber-files/"
+                    target="_blank"
+                  >
+                    Work with us
+                  </a>
+                </li>
+                <li class="list-unstyled-item">
+                  <a
+                    href="https://www.icij.org/investigations/uber-files/"
+                    target="_blank"
+                  >
+                    Journalists
+                  </a>
+                </li>
+              </ul>
+            </div>
+            <div class="col-6 col-lg-4">
               <h5 class="text-uppercase mb-3">
                 {{ $t('generic-footer.investigations') }}
               </h5>
+
+
               <!-- @slot List of investigations -->
               <slot name="investigations">
                 <ul class="list-unstyled">
@@ -94,7 +151,7 @@
                 </ul>
               </slot>
             </div>
-            <div class="col-md-4">
+            <div class="col-6 col-lg-4">
               <h5 class="text-uppercase mb-3">
                 {{ $t('generic-footer.follow-us') }}
               </h5>
@@ -180,6 +237,13 @@ export default {
     version: {
       type: String,
       default: null
+    },
+    /**
+     * Whether to include the About Us column or not
+     */
+    includeAboutUs: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {


### PR DESCRIPTION
This PR adds an optional 3about us" section is the Generic Footer component. 

This was required in the designs for the onboarding platform. Since this is exactly the same footer as in the main website, adding it directly in murmur seemed the best option for reusability. 

[Screencast from 20-02-2023 10:56:05.webm](https://user-images.githubusercontent.com/39140360/220073068-c6dcafd1-e807-4feb-9135-fab26e292b74.webm)
