### PR TITLE
enh: DigitsInput exposes joined inputs value

### DIFF
--- a/lib/components/DigitsInput.vue
+++ b/lib/components/DigitsInput.vue
@@ -5,10 +5,14 @@
         v-for="d in length"
         :key="d - 1"
         v-model="values[d - 1]"
-        :name="`digit-${d - 1}`"
         :class="`digits-input__container__input--${d - 1}`"
         class="digits-input__container__input w-0 form-control"
         @keyup.delete="focusToPreviousWhenEmpty(d - 1)"
+      >
+      <input 
+        type="hidden"
+        :value="joinedValues" 
+        :name="name"
       >
     </div>
   </div>  
@@ -47,6 +51,13 @@
       value: {
         type: [String, Number],
         default: ''
+      },
+      /**
+       * Name of the input
+       */
+       name: {
+        type: String,
+        default: ''
       }
     },
     data(): DigitsInputData {
@@ -56,7 +67,7 @@
       }
     },
     computed: {
-      joinedValues (): string {
+      joinedValues(): string {
         return filter(this.values, v => !isNaN(v as any)).join('')
       },
       /* eslint-disable no-undef */
@@ -73,7 +84,7 @@
         // Next input is the first non-empty input or the last input
         return this.inputs[this.joinedValues.length] || this.lastInput
       },
-      hasNextInput (): boolean {
+      hasNextInput(): boolean {
         return !!this.nextInput
       },
       lastInput(): HTMLElement | null {
@@ -105,24 +116,24 @@
         }
         this.focusToNextInput()
       },
-      joinedValues () {
+      joinedValues() {
         this.$emit('input', this.joinedValues)
       },
-      value () {
+      value() {
         this.values = String(this.value).split('').slice(0, this.length)
       }
     },  
-    async mounted () {
+    async mounted() {
       await this.$nextTick()
       this.mounted = true
     },
     methods: {
-      focusToNextInput () {
+      focusToNextInput() {
         if (this.hasNextInput) {
           this.nextInput?.focus()
         }
       },
-      focusToPreviousWhenEmpty (d: number) {
+      focusToPreviousWhenEmpty(d: number) {
         if (!this.values[d]) {
           this.inputs[d - 1]?.focus()
         }

--- a/tests/unit/components/DigitsInput.spec.ts
+++ b/tests/unit/components/DigitsInput.spec.ts
@@ -15,17 +15,21 @@ describe('DigitsInput', () => {
 
 
     beforeEach(() => {
-      const propsData = { length: 4 }
+      const propsData = { length: 4, name: 'inputName' }
       const attachTo = createContainer()
       wrapper = shallowMount(DigitsInput as any, { propsData, attachTo })
     })
 
-    it('should have 4inputs', () => {
-      expect(wrapper.emitted('input')).toBeFalsy()
+    it('should have 4 visible inputs and a hidden one', () => {
+      const inputs = wrapper.findAll('input');
+      expect(inputs).toHaveLength(5)
+      expect(
+        inputs.filter(input => input.attributes().type === 'hidden')
+      ).toHaveLength(1)
     })
 
     it('should not trigger input event yet', () => {
-      expect(wrapper.findAll('input')).toHaveLength(4)
+      expect(wrapper.emitted('input')).toBeFalsy()
     })
 
     it('should trigger input event when changing the first input', async () => {
@@ -138,6 +142,16 @@ describe('DigitsInput', () => {
       await wrapper.findAll('input').at(3).trigger('keyup.delete')
       const thirdInput = wrapper.findAll('input').at(2).element as HTMLInputElement
       expect(thirdInput).toBe(document.activeElement)
+    })
+
+    it('should set the name passed in prop to the last input', () => {
+      const input = wrapper.findAll('input').at(4);
+      expect(input.attributes().name).toBe('inputName')
+    })
+
+    it('should set the concatenated digits as a value to the last input', async () => {
+      await wrapper.findAll('input').at(0).setValue('2 0 4 8')
+      expect((wrapper.findAll('input').at(4).element as HTMLInputElement).value).toBe('2048')
     })
   })
 })


### PR DESCRIPTION
Before the PR, the DigitsInput component was only exposing single inputs values separatley. 
This PR adds a hidden input with the concatenated value and the possibility to pass a name to this input.
This allows DigitsInput to be used in forms so that the concatenated value  is used as payload of the form. 

